### PR TITLE
Add Dockerfile to do setup and convert .onnx models

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+docs/
+images/
+requirements-*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,165 @@ __pycache__/
 
 # system files
 .DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+models/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.9-slim
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /megadetector
+RUN pip3 install --no-cache-dir \
+      opencv-python-headless==4.6.0.66 \
+      onnx==1.12.0 \
+      onnxruntime==1.13.1 \
+      pandas==1.5.1 \
+      pyyaml==6.0 \
+      requests==2.28.1 \
+      tqdm==4.64.1 \
+      seaborn==0.12.1 \
+      torch==1.9.0 \
+      torchvision==0.10.0
+
+WORKDIR /megadetector/yolov5
+RUN git init . && \
+    git remote add origin https://github.com/ultralytics/yolov5.git && \
+    git fetch --depth 1 origin c23a441c9df7ca9b1f275e8c8719c949269160d1 && \ 
+    git checkout FETCH_HEAD
+
+WORKDIR /megadetector
+COPY . .
+
+CMD [ "./md2onnx.sh" ]

--- a/docker-convert-to-onnx.sh
+++ b/docker-convert-to-onnx.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+docker build -t megadetector-onnx .
+docker run --rm -it -v "$PWD"/models:/megadetector/models megadetector-onnx

--- a/md2onnx.sh
+++ b/md2onnx.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+md_v5a=/megadetector/models/md_v5a.0.0.pt
+md_v5b=/megadetector/models/md_v5b.0.0.pt
+
+echo "Downloading megadetector models..."
+if [ ! -f $md_v5a ]; then
+      wget --progress=dot:giga https://github.com/microsoft/CameraTraps/releases/download/v5.0/md_v5a.0.0.pt -O $md_v5a
+fi
+if [ ! -f $md_v5b ]; then
+      wget --progress=dot:giga https://github.com/microsoft/CameraTraps/releases/download/v5.0/md_v5b.0.0.pt -O $md_v5b
+fi
+
+echo "Converting megadetector models to onnx format..."
+cd /megadetector/yolov5 || exit
+python3 export.py \
+      --include onnx \
+      --weights $md_v5a \
+      --dynamic
+
+python3 export.py \
+      --include onnx \
+      --weights $md_v5b \
+      --dynamic
+
+echo "Created ./models/md_v5a.0.0.onnx and ./models/md_v5b.0.0.onnx"


### PR DESCRIPTION
This repo is amazing, thank you for creating it!  I've wanted to play with Megadetector for a long time, but only to integrate it into other programs I'm writing.  ONNX is the best way to do this, so I was thrilled to see that someone had already figured out how to do it!

I needed to convert these for myself, so wrote the Docker files necessary to turn your instructions into code.

Using `./docker-convert-to-onnx.sh` will build a Docker image then run a container that does the conversion.  The end product is a `./models/*` dir with both `.pt` and `.onnx` files.

I'm sending this as a PR in case others find it useful.  Whether you want to land this in your project or not, it's already done what I need!

Thanks again.